### PR TITLE
Fix output reference and module evaluation

### DIFF
--- a/Chapter 2/.github/workflows/manual-random-number-generator.yml
+++ b/Chapter 2/.github/workflows/manual-random-number-generator.yml
@@ -7,24 +7,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       number: ${{ steps.generate-number.outputs.number }}
-      is-even: ${{ steps.generate-number.outputs.is-even }}
+      is-even: ${{ steps.is-even.outputs.is-even }}
     steps:
       - id: generate-number
         run: echo "number=$(echo $RANDOM)" >> "$GITHUB_OUTPUT"
       - id: is-even
         run: |
-          echo "is-even=$(${{steps.generate-number.outputs.number}} % 2 == 0)" >> "$GITHUB_OUTPUT"
+          echo "is-even=$((${{steps.generate-number.outputs.number}} % 2 == 0))" >> "$GITHUB_OUTPUT"
           echo "The number is ${{steps.generate-number.outputs.number}}" >> $GITHUB_STEP_SUMMARY
   consumer-of-generator-odd:
     needs: random-number-generator
     runs-on: ubuntu-latest
-    if: ${{ ! needs.random-number-generator.outputs.is-even }}
+    if: ${{ needs.random-number-generator.outputs.is-even == 0 }}
     steps:
       - run: echo "The number is ${{ needs.random-number-generator.outputs.number }} is odd"
 
   consumer-of-generator-even:
     needs: random-number-generator
     runs-on: ubuntu-latest
-    if: ${{ needs.random-number-generator.outputs.is-even }}
+    if: ${{ needs.random-number-generator.outputs.is-even == 1 }}
     steps:
       - run: echo "The number is ${{ needs.random-number-generator.outputs.number }} is even"


### PR DESCRIPTION
The number generator always branches into the "odd number branch" as it can be seen in the following figure:

![error-a](https://github.com/user-attachments/assets/3afcd58c-7aaa-4aa7-994b-eb48df64ed59)
![error-b](https://github.com/user-attachments/assets/c53178a0-8098-436b-bfd4-1e6f6cd3cc5a)

This likely happens due to the `${{ steps.generate-number.outputs.is-even }}` which should reference the step `is-even`.

In addition, there occurs an error in:
```
echo "is-even=$(${{steps.generate-number.outputs.number}} % 2 == 0)" >> "$GITHUB_OUTPUT"
```

... that can be seen in the log output:
```
/home/runner/work/_temp/....sh: line 1: 26846: command not found
```

The "26846" is a generated random number. This can be fixed with another wrapping with `(...)` int the expression:
```
echo "is-even=$((${{steps.generate-number.outputs.number}} % 2 == 0))" >> "$GITHUB_OUTPUT"
```